### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,11 @@
 name: Java CI with Maven
 permissions:
   contents: read
+  id-token: write
+  actions: read
+  security-events: write
+  packages: read
+  deployments: write
 
 env:
   DB_URL: ${{secrets.DB_URL}}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,6 +11,7 @@ permissions:
   contents: read
   security-events: write
   actions: read
+  dependency-graph: write
 
 env:
   DB_URL: ${{secrets.DB_URL}}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 env:
   DB_URL: ${{secrets.DB_URL}}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,11 +9,8 @@
 name: Java CI with Maven
 permissions:
   contents: read
-  id-token: write
-  actions: read
   security-events: write
-  packages: read
-  deployments: write
+  actions: read
 
 env:
   DB_URL: ${{secrets.DB_URL}}


### PR DESCRIPTION
Potential fix for [https://github.com/RoadRomeo1/Resume_manager/security/code-scanning/3](https://github.com/RoadRomeo1/Resume_manager/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's tasks, the `contents: read` permission is sufficient for most steps, and no write permissions are required. The `permissions` block can be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions for improved control over access in the GitHub Actions Maven build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->